### PR TITLE
Add debug logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "laravel/framework": "^8.0",
         "php-http/discovery": "^1.14",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^2.0",

--- a/config/laravel-maileon.php
+++ b/config/laravel-maileon.php
@@ -1,18 +1,18 @@
 <?php
 
 return [
-    'api-url'       => env('MAILEON_API_URL', 'https://api.maileon.com/1.0'),
-    'api-key'       => env('MAILEON_API_KEY'),
-    'contact-event' => env('MAILEON_TRANSACTIONAL_CONTACT_EVENT'),
+    'api-url'        => env('MAILEON_API_URL', 'https://api.maileon.com/1.0'),
+    'api-key'        => env('MAILEON_API_KEY'),
+    'contact-event'  => env('MAILEON_TRANSACTIONAL_CONTACT_EVENT'),
 
     // Specify the FQN to the PSR-18 compliant HTTP Client you want to use.
     // If none is explicitly provided, the package will try to find a PSR-18
     // compliant HTTP Client using "php-http/discovery" and use that.
-    'http-client'   => null,
+    'http-client'    => null,
 
     // Specify the FQN to the PSR-3 compliant logger you wish to use. If none
     // is provided, it will use whatever logger is bound to the
     // Psr\Log\LoggerInterface. If that resolve into null, all
-    'logger'        => null,
-    'log-requests'  => env('MAILEON_LOG_REQUESTS', env('APP_DEBUG', false)),
+    'logger'         => null,
+    'enable-logging' => env('MAILEON_ENABLE_LOGGING', env('APP_DEBUG', false)),
 ];

--- a/config/laravel-maileon.php
+++ b/config/laravel-maileon.php
@@ -9,4 +9,10 @@ return [
     // If none is explicitly provided, the package will try to find a PSR-18
     // compliant HTTP Client using "php-http/discovery" and use that.
     'http-client'   => null,
+
+    // Specify the FQN to the PSR-3 compliant logger you wish to use. If none
+    // is provided, it will use whatever logger is bound to the
+    // Psr\Log\LoggerInterface. If that resolve into null, all
+    'logger'        => null,
+    'log-requests'  => env('MAILEON_LOG_REQUESTS', env('APP_DEBUG', false)),
 ];

--- a/src/DataObjects/MaileonConfiguration.php
+++ b/src/DataObjects/MaileonConfiguration.php
@@ -11,7 +11,7 @@ class MaileonConfiguration
     protected string $contactEvent;
     protected ?string $httpClient;
     protected ?string $logger;
-    protected bool $debugMode;
+    protected bool $logRequests;
 
     public function __construct(
         string $apiUrl,
@@ -19,14 +19,14 @@ class MaileonConfiguration
         string $contactEvent,
         ?string $httpClient,
         ?string $logger = null,
-        bool $debugMode = false
+        bool $logRequests = false
     ) {
         $this->apiUrl       = $apiUrl;
         $this->apiKey       = $apiKey;
         $this->contactEvent = $contactEvent;
         $this->httpClient   = $httpClient;
         $this->logger       = $logger;
-        $this->debugMode    = $debugMode;
+        $this->logRequests  = $logRequests;
     }
 
     public function getApiUrl(): string
@@ -54,8 +54,8 @@ class MaileonConfiguration
         return $this->logger;
     }
 
-    public function debugMode(): bool
+    public function logRequests(): bool
     {
-        return $this->debugMode;
+        return $this->logRequests;
     }
 }

--- a/src/DataObjects/MaileonConfiguration.php
+++ b/src/DataObjects/MaileonConfiguration.php
@@ -10,17 +10,23 @@ class MaileonConfiguration
     protected string $apiKey;
     protected string $contactEvent;
     protected ?string $httpClient;
+    protected ?string $logger;
+    protected bool $debugMode;
 
     public function __construct(
         string $apiUrl,
         string $apiKey,
         string $contactEvent,
-        ?string $httpClient
+        ?string $httpClient,
+        ?string $logger = null,
+        bool $debugMode = false
     ) {
         $this->apiUrl       = $apiUrl;
         $this->apiKey       = $apiKey;
         $this->contactEvent = $contactEvent;
         $this->httpClient   = $httpClient;
+        $this->logger       = $logger;
+        $this->debugMode    = $debugMode;
     }
 
     public function getApiUrl(): string
@@ -41,5 +47,15 @@ class MaileonConfiguration
     public function getHttpClient(): ?string
     {
         return $this->httpClient;
+    }
+
+    public function getLogger(): ?string
+    {
+        return $this->logger;
+    }
+
+    public function debugMode(): bool
+    {
+        return $this->debugMode;
     }
 }

--- a/src/DataObjects/MaileonConfiguration.php
+++ b/src/DataObjects/MaileonConfiguration.php
@@ -11,7 +11,7 @@ class MaileonConfiguration
     protected string $contactEvent;
     protected ?string $httpClient;
     protected ?string $logger;
-    protected bool $logRequests;
+    protected bool $enableLogging;
 
     public function __construct(
         string $apiUrl,
@@ -19,14 +19,14 @@ class MaileonConfiguration
         string $contactEvent,
         ?string $httpClient,
         ?string $logger = null,
-        bool $logRequests = false
+        bool $enableLogging = false
     ) {
-        $this->apiUrl       = $apiUrl;
-        $this->apiKey       = $apiKey;
-        $this->contactEvent = $contactEvent;
-        $this->httpClient   = $httpClient;
-        $this->logger       = $logger;
-        $this->logRequests  = $logRequests;
+        $this->apiUrl        = $apiUrl;
+        $this->apiKey        = $apiKey;
+        $this->contactEvent  = $contactEvent;
+        $this->httpClient    = $httpClient;
+        $this->logger        = $logger;
+        $this->enableLogging = $enableLogging;
     }
 
     public function getApiUrl(): string
@@ -54,8 +54,8 @@ class MaileonConfiguration
         return $this->logger;
     }
 
-    public function logRequests(): bool
+    public function enableLogging(): bool
     {
-        return $this->logRequests;
+        return $this->enableLogging;
     }
 }

--- a/src/MaileonClient.php
+++ b/src/MaileonClient.php
@@ -65,7 +65,7 @@ class MaileonClient implements MaileonClientInterface
             )
         );
 
-        if ($this->maileonConfiguration->debugMode() && $this->logger) {
+        if ($this->maileonConfiguration->logRequests() && $this->logger) {
             $this->logger->debug('Sending transactional mail request to Maileon.', [
                 'requestBody' => $requestBody,
                 'response'    => $response,

--- a/src/MaileonClient.php
+++ b/src/MaileonClient.php
@@ -65,7 +65,7 @@ class MaileonClient implements MaileonClientInterface
             )
         );
 
-        if ($this->maileonConfiguration->logRequests() && $this->logger) {
+        if ($this->maileonConfiguration->enableLogging() && $this->logger) {
             $this->logger->debug('Sending transactional mail request to Maileon.', [
                 'requestBody' => $requestBody,
                 'response'    => $response,

--- a/src/MaileonClient.php
+++ b/src/MaileonClient.php
@@ -11,26 +11,31 @@ use DennisKoster\LaravelMaileon\Enums\ContactPermissionsEnum;
 use DennisKoster\LaravelMaileon\Enums\RequestMethodsEnum;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
 
 class MaileonClient implements MaileonClientInterface
 {
     protected ClientInterface $httpClient;
     protected RequestFactoryInterface $requestFactory;
     protected MaileonConfiguration $maileonConfiguration;
+    protected ?LoggerInterface $logger;
 
     /**
      * @param ClientInterface         $httpClient
      * @param RequestFactoryInterface $requestFactory
      * @param MaileonConfiguration    $maileonConfiguration
+     * @param LoggerInterface|null    $logger
      */
     public function __construct(
         ClientInterface $httpClient,
         RequestFactoryInterface $requestFactory,
-        MaileonConfiguration $maileonConfiguration
+        MaileonConfiguration $maileonConfiguration,
+        ?LoggerInterface $logger = null
     ) {
         $this->httpClient           = $httpClient;
         $this->requestFactory       = $requestFactory;
         $this->maileonConfiguration = $maileonConfiguration;
+        $this->logger               = $logger;
     }
 
     public function sendEmail(
@@ -38,24 +43,35 @@ class MaileonClient implements MaileonClientInterface
         string $subject,
         string $contents
     ): ResponseInterface {
-        return $this->httpClient->sendRequest(
+        $requestBody = [
+            'typeName' => $this->maileonConfiguration->getContactEvent(),
+            'import'   => [
+                'contact' => [
+                    'email'      => $recipientEmail,
+                    'permission' => ContactPermissionsEnum::OTHER,
+                ],
+            ],
+            'content'  => [
+                'subject'   => $subject,
+                'body_html' => [$contents],
+            ],
+        ];
+
+        $response = $this->httpClient->sendRequest(
             $this->requestFactory->make(
                 '/transactions',
                 RequestMethodsEnum::POST(),
-                [
-                    'typeName' => $this->maileonConfiguration->getContactEvent(),
-                    'import'   => [
-                        'contact' => [
-                            'email'      => $recipientEmail,
-                            'permission' => ContactPermissionsEnum::OTHER,
-                        ],
-                    ],
-                    'content'  => [
-                        'subject'   => $subject,
-                        'body_html' => [$contents],
-                    ],
-                ]
+                $requestBody
             )
         );
+
+        if ($this->maileonConfiguration->debugMode() && $this->logger) {
+            $this->logger->debug('Sending transactional mail request to Maileon.', [
+                'requestBody' => $requestBody,
+                'response'    => $response,
+            ]);
+        }
+
+        return $response;
     }
 }

--- a/src/Providers/LaravelMaileonServiceProvider.php
+++ b/src/Providers/LaravelMaileonServiceProvider.php
@@ -46,6 +46,7 @@ class LaravelMaileonServiceProvider extends ServiceProvider
                 $config->get('laravel-maileon.contact-event'),
                 $config->get('laravel-maileon.http-client'),
                 $config->get('laravel-maileon.logger'),
+                $config->get('laravel-maileon.enable-logging'),
             );
         });
 

--- a/src/Providers/LaravelMaileonServiceProvider.php
+++ b/src/Providers/LaravelMaileonServiceProvider.php
@@ -46,7 +46,7 @@ class LaravelMaileonServiceProvider extends ServiceProvider
                 $config->get('laravel-maileon.contact-event'),
                 $config->get('laravel-maileon.http-client'),
                 $config->get('laravel-maileon.logger'),
-                $config->get('laravel-maileon.enable-logging'),
+                (boolean) $config->get('laravel-maileon.enable-logging'),
             );
         });
 

--- a/tests/Unit/DataObjects/MaileonConfigurationTest.php
+++ b/tests/Unit/DataObjects/MaileonConfigurationTest.php
@@ -28,7 +28,7 @@ class MaileonConfigurationTest extends AbstractUnitTest
         static::assertSame('API_Transactional', $configuration->getContactEvent());
         static::assertNull($configuration->getHttpClient());
         static::assertNull($configuration->getLogger());
-        static::assertFalse($configuration->logRequests());
+        static::assertFalse($configuration->enableLogging());
     }
 
     /**
@@ -76,6 +76,6 @@ class MaileonConfigurationTest extends AbstractUnitTest
             true
         );
 
-        static::assertTrue($configuration->logRequests());
+        static::assertTrue($configuration->enableLogging());
     }
 }

--- a/tests/Unit/DataObjects/MaileonConfigurationTest.php
+++ b/tests/Unit/DataObjects/MaileonConfigurationTest.php
@@ -28,7 +28,7 @@ class MaileonConfigurationTest extends AbstractUnitTest
         static::assertSame('API_Transactional', $configuration->getContactEvent());
         static::assertNull($configuration->getHttpClient());
         static::assertNull($configuration->getLogger());
-        static::assertFalse($configuration->debugMode());
+        static::assertFalse($configuration->logRequests());
     }
 
     /**
@@ -65,7 +65,7 @@ class MaileonConfigurationTest extends AbstractUnitTest
     /**
      * @test
      */
-    public function it_sets_debug_mode_to_true(): void
+    public function it_sets_log_requests_to_true(): void
     {
         $configuration = new MaileonConfiguration(
             'https://api-url.com',
@@ -76,6 +76,6 @@ class MaileonConfigurationTest extends AbstractUnitTest
             true
         );
 
-        static::assertTrue($configuration->debugMode());
+        static::assertTrue($configuration->logRequests());
     }
 }

--- a/tests/Unit/DataObjects/MaileonConfigurationTest.php
+++ b/tests/Unit/DataObjects/MaileonConfigurationTest.php
@@ -7,6 +7,7 @@ namespace DennisKoster\LaravelMaileon\Tests\Unit\DataObjects;
 use DennisKoster\LaravelMaileon\DataObjects\MaileonConfiguration;
 use DennisKoster\LaravelMaileon\Tests\Unit\AbstractUnitTest;
 use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
 
 class MaileonConfigurationTest extends AbstractUnitTest
 {
@@ -26,6 +27,8 @@ class MaileonConfigurationTest extends AbstractUnitTest
         static::assertSame('some-secret-api-key', $configuration->getApiKey());
         static::assertSame('API_Transactional', $configuration->getContactEvent());
         static::assertNull($configuration->getHttpClient());
+        static::assertNull($configuration->getLogger());
+        static::assertFalse($configuration->debugMode());
     }
 
     /**
@@ -37,9 +40,42 @@ class MaileonConfigurationTest extends AbstractUnitTest
             'https://api-url.com',
             'some-secret-api-key',
             'API_Transactional',
-            ClientInterface::class
+            ClientInterface::class,
         );
 
         static::assertSame(ClientInterface::class, $configuration->getHttpClient());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_the_logger_fqn(): void
+    {
+        $configuration = new MaileonConfiguration(
+            'https://api-url.com',
+            'some-secret-api-key',
+            'API_Transactional',
+            ClientInterface::class,
+            LoggerInterface::class,
+        );
+
+        static::assertSame(LoggerInterface::class, $configuration->getLogger());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_debug_mode_to_true(): void
+    {
+        $configuration = new MaileonConfiguration(
+            'https://api-url.com',
+            'some-secret-api-key',
+            'API_Transactional',
+            null,
+            null,
+            true
+        );
+
+        static::assertTrue($configuration->debugMode());
     }
 }

--- a/tests/Unit/MaileonClientTest.php
+++ b/tests/Unit/MaileonClientTest.php
@@ -25,7 +25,7 @@ class MaileonClientTest extends AbstractUnitTest
         $requestFactory = Mockery::mock(RequestFactoryInterface::class);
         $configuration  = Mockery::mock(MaileonConfiguration::class, [
             'getContactEvent' => 'API_Transactional',
-            'debugMode'       => false,
+            'logRequests'     => false,
         ]);
         $request        = Mockery::mock(RequestInterface::class);
 
@@ -79,7 +79,7 @@ class MaileonClientTest extends AbstractUnitTest
         $requestFactory = Mockery::mock(RequestFactoryInterface::class);
         $configuration  = Mockery::mock(MaileonConfiguration::class, [
             'getContactEvent' => 'API_Transactional',
-            'debugMode'       => true,
+            'logRequests'     => true,
         ]);
         $request        = Mockery::mock(RequestInterface::class);
 

--- a/tests/Unit/MaileonClientTest.php
+++ b/tests/Unit/MaileonClientTest.php
@@ -25,7 +25,7 @@ class MaileonClientTest extends AbstractUnitTest
         $requestFactory = Mockery::mock(RequestFactoryInterface::class);
         $configuration  = Mockery::mock(MaileonConfiguration::class, [
             'getContactEvent' => 'API_Transactional',
-            'logRequests'     => false,
+            'enableLogging'   => false,
         ]);
         $request        = Mockery::mock(RequestInterface::class);
 
@@ -79,7 +79,7 @@ class MaileonClientTest extends AbstractUnitTest
         $requestFactory = Mockery::mock(RequestFactoryInterface::class);
         $configuration  = Mockery::mock(MaileonConfiguration::class, [
             'getContactEvent' => 'API_Transactional',
-            'logRequests'     => true,
+            'enableLogging'   => true,
         ]);
         $request        = Mockery::mock(RequestInterface::class);
 

--- a/tests/Unit/MaileonClientTest.php
+++ b/tests/Unit/MaileonClientTest.php
@@ -12,6 +12,7 @@ use Mockery;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
 
 class MaileonClientTest extends AbstractUnitTest
 {
@@ -24,6 +25,7 @@ class MaileonClientTest extends AbstractUnitTest
         $requestFactory = Mockery::mock(RequestFactoryInterface::class);
         $configuration  = Mockery::mock(MaileonConfiguration::class, [
             'getContactEvent' => 'API_Transactional',
+            'debugMode'       => false,
         ]);
         $request        = Mockery::mock(RequestInterface::class);
 
@@ -59,6 +61,70 @@ class MaileonClientTest extends AbstractUnitTest
             $httpClient,
             $requestFactory,
             $configuration
+        );
+
+        $maileonClient->sendEmail(
+            'john.doe@example.com',
+            'Test email',
+            'This is a test email.'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_requests_when_debug_mode_is_set_to_true_and_a_logger_is_provided(): void
+    {
+        $httpClient     = Mockery::mock(ClientInterface::class);
+        $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+        $configuration  = Mockery::mock(MaileonConfiguration::class, [
+            'getContactEvent' => 'API_Transactional',
+            'debugMode'       => true,
+        ]);
+        $request        = Mockery::mock(RequestInterface::class);
+
+        $requestFactory
+            ->shouldReceive('make')
+            ->once()
+            ->andReturn($request);
+
+        $response = Mockery::mock(ResponseInterface::class);
+
+        $httpClient
+            ->shouldReceive('sendRequest')
+            ->once()
+            ->with($request)
+            ->andReturn($response);
+
+        /** @var LoggerInterface $logger */
+        $logger = Mockery::mock(LoggerInterface::class)
+            ->shouldReceive('debug')
+            ->once()
+            ->with('Sending transactional mail request to Maileon.', [
+                'requestBody' => [
+                    'typeName' => 'API_Transactional',
+                    'import'   => [
+                        'contact' => [
+                            'email'      => 'john.doe@example.com',
+                            'permission' => 6,
+                        ],
+                    ],
+                    'content'  => [
+                        'subject'   => 'Test email',
+                        'body_html' => [
+                            'This is a test email.',
+                        ],
+                    ],
+                ],
+                'response'    => $response,
+            ])
+            ->getMock();
+
+        $maileonClient = new MaileonClient(
+            $httpClient,
+            $requestFactory,
+            $configuration,
+            $logger
         );
 
         $maileonClient->sendEmail(


### PR DESCRIPTION
Added two config values:
* `log-requests` (boolean).
* `logger` (FQN to logger class or null, to use the default `LoggerInterface` binding.

When `log-requests` is set to true and a logger instance is available, requests to Maileon and their related responses will be logged.